### PR TITLE
Change Controller Name

### DIFF
--- a/SICI/Controllers/EnviarNotificacionController.cs
+++ b/SICI/Controllers/EnviarNotificacionController.cs
@@ -8,9 +8,9 @@ using System.Web.Mvc;
 
 namespace SICI.Controllers
 {
-    public class EnviarNotificacionController : Controller
+    public class NotificacionController : Controller
     {
-        // GET: EnviarNotificacion
+        // GET: Notificacion
         public ActionResult Index()
         {
             return View();

--- a/SICI/SICI.csproj
+++ b/SICI/SICI.csproj
@@ -172,7 +172,7 @@
     <Compile Include="App_Start\Startup.Auth.cs" />
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\AspNetUsersController.cs" />
-    <Compile Include="Controllers\EnviarNotificacionController.cs" />
+    <Compile Include="Controllers\NotificacionController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\ManageController.cs" />
     <Compile Include="Controllers\Notificacion.cs" />


### PR DESCRIPTION
Following the clear code rules we should avoid class names with verbs. Don' forget to change the name in other places.